### PR TITLE
Extract publish date from blog post file paths

### DIFF
--- a/packages/uc-site/src/components/Markdown.astro
+++ b/packages/uc-site/src/components/Markdown.astro
@@ -1,6 +1,6 @@
 ---
 import type { MarkdownLayoutProps } from "astro";
-import PageLayout from "uc-theme/components/PageLayout.astro";
+import { PageLayout } from "uc-theme/components";
 
 type Props = MarkdownLayoutProps<{
   title: string;

--- a/packages/uc-site/src/content.config.ts
+++ b/packages/uc-site/src/content.config.ts
@@ -1,8 +1,9 @@
 import { defineCollection, z, reference } from "astro:content";
-import { glob, file } from "astro/loaders";
+import { file } from "astro/loaders";
+import { blogLoader } from "uc-theme/blog";
 
 const blog = defineCollection({
-  loader: glob({
+  loader: blogLoader({
     pattern: "**/index.md",
     base: "./src/content/blog",
   }),

--- a/packages/uc-site/src/pages/404.astro
+++ b/packages/uc-site/src/pages/404.astro
@@ -1,5 +1,5 @@
 ---
-import PageLayout from "uc-theme/components/PageLayout.astro";
+import { PageLayout } from "uc-theme/components";
 ---
 
 <PageLayout title="Not Found">

--- a/packages/uc-site/src/pages/blog/[...page].astro
+++ b/packages/uc-site/src/pages/blog/[...page].astro
@@ -2,7 +2,7 @@
 import { getCollection } from "astro:content";
 import type { GetStaticPaths, Page } from "astro";
 import type { CollectionEntry } from "astro:content";
-import PageLayout from "uc-theme/components/PageLayout.astro";
+import { PageLayout } from "uc-theme/components";
 import { getBlogPublishedAt } from "uc-theme/blog";
 
 export const getStaticPaths = (async ({ paginate }) => {

--- a/packages/uc-site/src/pages/blog/[...page].astro
+++ b/packages/uc-site/src/pages/blog/[...page].astro
@@ -3,6 +3,7 @@ import { getCollection } from "astro:content";
 import type { GetStaticPaths, Page } from "astro";
 import type { CollectionEntry } from "astro:content";
 import PageLayout from "uc-theme/components/PageLayout.astro";
+import { getBlogPublishedAt } from "uc-theme/blog";
 
 export const getStaticPaths = (async ({ paginate }) => {
   const posts = await getCollection("blog");
@@ -21,11 +22,16 @@ const { page } = Astro.props;
   <h1>Blog</h1>
   <ol>
     {
-      page.data.map((post) => (
-        <li>
-          <a href={`/blog/${post.id}`}>{post.data.title}</a>
-        </li>
-      ))
+      page.data.map((post) => {
+        const publishedAt = getBlogPublishedAt(post);
+
+        return (
+          <li>
+            {publishedAt.toLocaleDateString()}{" "}
+            <a href={`/blog/${post.id}`}>{post.data.title}</a>
+          </li>
+        );
+      })
     }
   </ol>
 </PageLayout>

--- a/packages/uc-site/src/pages/blog/[id].astro
+++ b/packages/uc-site/src/pages/blog/[id].astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection, render, getEntries } from "astro:content";
-import PageLayout from "uc-theme/components/PageLayout.astro";
+import { PageLayout } from "uc-theme/components";
 import { getBlogPublishedAt } from "uc-theme/blog";
 
 export async function getStaticPaths() {

--- a/packages/uc-site/src/pages/blog/[id].astro
+++ b/packages/uc-site/src/pages/blog/[id].astro
@@ -1,22 +1,34 @@
 ---
 import { getCollection, render, getEntries } from "astro:content";
 import PageLayout from "uc-theme/components/PageLayout.astro";
+import { getBlogPublishedAt } from "uc-theme/blog";
 
 export async function getStaticPaths() {
   const posts = await getCollection("blog");
-  return posts.map((post) => ({
-    params: { id: post.id },
-    props: { post },
-  }));
+  return posts.map((post) => {
+    const publishedAt = getBlogPublishedAt(post);
+
+    return {
+      params: { id: post.id },
+      props: {
+        post,
+        publishedAt,
+      },
+    };
+  });
 }
 
-const { post } = Astro.props;
+const { post, publishedAt } = Astro.props;
 const authors = await getEntries(post.data.authors);
 const { Content } = await render(post);
 ---
 
 <PageLayout title={post.data.title}>
   <h1>{post.data.title}</h1>
-  <p>Published by {authors.map((author) => author.data.name).join(", ")}</p>
+  <p>
+    Published on {publishedAt.toLocaleDateString()} by {
+      authors.map((author) => author.data.name).join(", ")
+    }
+  </p>
   <Content />
 </PageLayout>

--- a/packages/uc-theme/README.md
+++ b/packages/uc-theme/README.md
@@ -57,7 +57,7 @@ import { PageLayout } from "uc-theme/components";
 
 ### Blogs
 
-The `uc-theme/blogs` module includes utilties for working with blogs.
+The `uc-theme/blogs` module includes utilities for working with blogs.
 
 We expect blogs to follow the file naming convention: `YYYY-MM-DD-*`. This gives us two benefits:
 

--- a/packages/uc-theme/README.md
+++ b/packages/uc-theme/README.md
@@ -25,9 +25,22 @@ export default defineConfig({
 });
 ```
 
-## Usage
+## Configuration
 
-Import components found in `/src/components`:
+| Property           | Type       | Required | Description                                                   |
+| ------------------ | ---------- | -------- | ------------------------------------------------------------- |
+| `siteTitle`        | `string`   | Yes      | Site title                                                    |
+| `defaultImage`     | `string`   | Yes      | Default image to display on pages which don't have an `image` |
+| `menus`            | `object[]` | Yes      | Site menus                                                    |
+| `menus.header`     | `object[]` | Yes      | Header menu                                                   |
+| `menus.headerCtas` | `object[]` | Yes      | Header menu - CTAs                                            |
+| `menus.footer`     | `object[]` | Yes      | Footer menu                                                   |
+
+## Modules
+
+### Components
+
+The `uc-theme/components` module includes different components for your pages.
 
 ```astro
 ---
@@ -40,13 +53,45 @@ import PageLayout from "uc-theme/components/PageLayout.astro";
 </PageLayout>
 ```
 
-## Configuration
+### Blogs
 
-| Property           | Type       | Required | Description                                                   |
-| ------------------ | ---------- | -------- | ------------------------------------------------------------- |
-| `siteTitle`        | `string`   | Yes      | Site title                                                    |
-| `defaultImage`     | `string`   | Yes      | Default image to display on pages which don't have an `image` |
-| `menus`            | `object[]` | Yes      | Site menus                                                    |
-| `menus.header`     | `object[]` | Yes      | Header menu                                                   |
-| `menus.headerCtas` | `object[]` | Yes      | Header menu - CTAs                                            |
-| `menus.footer`     | `object[]` | Yes      | Footer menu                                                   |
+The `uc-theme/blogs` module includes utilties for working with blogs.
+
+We expect blogs to follow the file naming convention: `YYYY-MM-DD-*`. This gives us two benefits:
+
+1. The published date is built into the filename.
+2. This format allows us to keep the blogs directory organized by publish date.
+
+#### How to use
+
+In your `content.config.ts` file:
+
+```ts
+import { blogLoader } from "uc-theme/blog";
+
+const blog = defineCollection({
+  loader: blogLoader({
+    pattern: "**/index.md",
+    base: "./src/content/blog",
+  }),
+});
+
+export const collections = { blog };
+```
+
+This will ensure that blogs are imported properly using the proper naming convention.
+
+Then, in your pages:
+
+```ts
+import { getBlogPublishedAt } from "uc-theme/blog";
+
+// Look up post named 2025-05-08-hello-world
+const post = await getEntry("blog", "hello-world");
+
+// this will be "hello-world"
+console.log(post.id);
+
+// this will be a Date set to 2025-05-08
+const publishedAt = getBlogPublishedAt(post);
+```

--- a/packages/uc-theme/README.md
+++ b/packages/uc-theme/README.md
@@ -38,13 +38,15 @@ export default defineConfig({
 
 ## Modules
 
+The `uc-theme` package exports multiple modules.
+
 ### Components
 
 The `uc-theme/components` module includes different components for your pages.
 
 ```astro
 ---
-import PageLayout from "uc-theme/components/PageLayout.astro";
+import { PageLayout } from "uc-theme/components";
 ---
 
 <PageLayout title="My awesome page!">

--- a/packages/uc-theme/package.json
+++ b/packages/uc-theme/package.json
@@ -12,7 +12,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./blog": "./src/blog/index.ts",
-    "./components/*": "./src/components/*"
+    "./components": "./src/components/index.ts"
   },
   "keywords": [],
   "author": "jakebellacera",

--- a/packages/uc-theme/package.json
+++ b/packages/uc-theme/package.json
@@ -11,6 +11,7 @@
   },
   "exports": {
     ".": "./src/index.ts",
+    "./blog": "./src/blog/index.ts",
     "./components/*": "./src/components/*"
   },
   "keywords": [],

--- a/packages/uc-theme/src/blog/blogLoader.ts
+++ b/packages/uc-theme/src/blog/blogLoader.ts
@@ -1,0 +1,34 @@
+import type { Loader } from "astro/loaders";
+import { glob } from "astro/loaders";
+
+interface BlogLoaderOptions {
+  pattern: string | Array<string>;
+  base: string | URL;
+}
+
+/**
+ * Loads blogs from a directory. Requires each blog filepath to match format: YYYY-MM-DD-*
+ */
+export const blogLoader = (options: BlogLoaderOptions): Loader => {
+  const { pattern, base } = options;
+
+  return glob({
+    pattern,
+    base,
+    generateId: ({ entry, data }) => {
+      if (data.slug) {
+        return data.slug as string;
+      }
+
+      const matches = entry.match(/\d{4}-\d{2}-\d{2}-([\w|-]+)/);
+
+      if (!matches || matches[1] === undefined) {
+        throw new Error(
+          `Blog path must match format: YYYY-MM-DD-*. Provided: ${entry}`,
+        );
+      }
+
+      return matches[1];
+    },
+  });
+};

--- a/packages/uc-theme/src/blog/getBlogPublishedAt.ts
+++ b/packages/uc-theme/src/blog/getBlogPublishedAt.ts
@@ -1,0 +1,21 @@
+interface AnyPost {
+  filePath?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export const getBlogPublishedAt = (post: AnyPost): Date => {
+  const { filePath } = post;
+
+  if (!filePath) {
+    throw new Error("Please provide a valid Blog post");
+  }
+
+  const dateMatch = filePath.match(/(\d{4}-\d{2}-\d{2})-./);
+
+  if (dateMatch === null || dateMatch[1] === undefined) {
+    throw new Error("Blog file path must include format: YYYY-MM-DD-*.");
+  }
+
+  return new Date(`${dateMatch[1]}T00:00:00Z`);
+};

--- a/packages/uc-theme/src/blog/index.ts
+++ b/packages/uc-theme/src/blog/index.ts
@@ -1,0 +1,2 @@
+export { blogLoader } from "./blogLoader";
+export { getBlogPublishedAt } from "./getBlogPublishedAt";

--- a/packages/uc-theme/src/components/index.ts
+++ b/packages/uc-theme/src/components/index.ts
@@ -1,0 +1,1 @@
+export { default as PageLayout } from "./PageLayout.astro";


### PR DESCRIPTION
- Export publish date from blog post file paths (`YYYY-MM-DD-*`)
- Rewrite blog post URLs so that they don't include the publish date. This means the blog posts are now matching the URLs the existing site had now.
- Moved blog utils into theme — in the future we will move more of the blog stuff here so that it is self-contained in the theme.
- Reorganized theme's exports into "modules" — we currently have two modules: `blog` and `components`.
- Using named exports for the theme's components module now.